### PR TITLE
added Github workflow to run cargo build

### DIFF
--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -1,0 +1,17 @@
+on: [push]
+
+name: Rust Build
+
+jobs:
+  build_and_test:
+    name: Run cargo build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features

--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -15,3 +15,4 @@ jobs:
         with:
           command: build
           args: --release --all-features
+          


### PR DESCRIPTION
Signed-off-by: Zethson <lukas.heumos@posteo.net>

Dear Jerven,

triggered on any push to any branch.
Runs `cargo build --release --all-features`.

I tested it on my fork and it passes.